### PR TITLE
fix: overflowing dots on instruction panel background

### DIFF
--- a/src/components/PanelContainer.css
+++ b/src/components/PanelContainer.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   background-color: #02000e;
   z-index: 2;
+  overflow-y: hidden;
 }
 
 .collapsed {


### PR DESCRIPTION
overflowing dots caused the whole page to scroll vertically on small screens