### PR TITLE
fixes: map size, alignment, map zoom control buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,7 +39,7 @@ body {
 .content-container__right {
   display: flex;
   flex: 1;
-  flex-direction: column-reverse;
+  flex-direction: column;
   height: 100vh;
   width: 100%;
 }
@@ -66,10 +66,10 @@ body {
 }
 
 .map-container {
-  position: fixed;
-  left:  0;
-  top:  0;
-  width: 100vw;
+  position: relative;
+  flex: 1 1;
+  margin-bottom: -30px; /* hiding the mapbox logo at the bottom of the map */
+  z-index: 0;
 }
 
 .mapboxgl-ctrl-attrib-inner {

--- a/src/components/LessonPager.css
+++ b/src/components/LessonPager.css
@@ -7,7 +7,6 @@
 .pager {
   flex: 1;
   padding: 0 32px;
-  padding-right: 48px; /* to account for scrollbar width */
   overflow: hidden;
   display: flex;
   flex-direction: row;

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -5,7 +5,6 @@
   align-items: center;
   padding: 12px 22px;
   margin-top: 20px;
-  margin-right: 16px; /* account for width of scrollbar in lesson content */
   font-size: 18px;
 }
 

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -61,7 +61,7 @@
   border: none;
   position: fixed;
   top: 30.5px;
-  right: 22px;
+  right: 40px;
   font-size: 16px;
   letter-spacing: 0.5px;
   font-family: 'Anek Latin';


### PR DESCRIPTION
- change map from a full-screen background element to only occupy size of  its container
- vertically align navbar with pager buttons to match figma design
- shift bug button to make space for map zoom control buttons